### PR TITLE
Update init script to reference /etc/default file

### DIFF
--- a/contrib/httpuploadcomponent
+++ b/contrib/httpuploadcomponent
@@ -23,6 +23,10 @@ USER=prosody
 export LOGNAME=$USER
 
 test -x $DAEMON || exit 0
+
+# Allow user to override default values listed above
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
 set -e
 
 function _start() {


### PR DESCRIPTION
Instead of requiring the user to modify the /etc/init.d/httpuploadcomponent file, the init.d script should support checking for and including the corresponding /etc/default/httpuploadcomponent conf file (if present). This will allow the user to customize the settings for the daemon to match their specific environment.

References:

- https://www.debian.org/doc/debian-policy/ch-opersys.html